### PR TITLE
influxdb2 downsampling tasks

### DIFF
--- a/infra/influxdb2/tasks/downsampling/README
+++ b/infra/influxdb2/tasks/downsampling/README
@@ -1,0 +1,3 @@
+Downsampling for the "infra" bucket
+
+Based on: https://github.com/influxdata/community-templates/tree/master/downsampling

--- a/infra/influxdb2/tasks/downsampling/downsampling_home.flux
+++ b/infra/influxdb2/tasks/downsampling/downsampling_home.flux
@@ -1,0 +1,90 @@
+// Query to dowsample data from "infra" bucket
+// https://github.com/influxdata/community-templates/blob/master/downsampling/all_inputs/downsampling_tasks.yml
+
+fromBucket = "home"
+toBucket = "home_" + string(v: task.every)
+	all_data = from(bucket: fromBucket)
+		|> range(start: -task.every)
+		|> filter(fn: (r) =>
+			(r._measurement == "Owens")
+				and exists r._value and (r._value >= 0 or r._value < 0))
+	all_data
+		|> aggregateWindow(every: task.every, fn: mean)
+		|> set(key: "aggregate", value: "mean")
+		|> set(key: "rollup_interval", value: string(v: task.every))
+		|> to(bucket: toBucket)
+	all_data
+		|> aggregateWindow(every: task.every, fn: min)
+		|> set(key: "aggregate", value: "min")
+		|> set(key: "rollup_interval", value: string(v: task.every))
+		|> to(bucket: toBucket)
+	all_data
+		|> aggregateWindow(every: task.every, fn: max)
+		|> set(key: "aggregate", value: "max")
+		|> set(key: "rollup_interval", value: string(v: task.every))
+		|> to(bucket: toBucket)
+	all_data
+		|> aggregateWindow(every: task.every, fn: sum)
+		|> set(key: "aggregate", value: "sum")
+		|> set(key: "rollup_interval", value: string(v: task.every))
+		|> to(bucket: toBucket)
+	all_data
+		|> map(fn: (r) =>
+			({r with _value: float(v: r._value)}))
+		|> quantile(
+			column: "_value",
+			q: 0.999,
+			method: "estimate_tdigest",
+			compression: 1000.0,
+		)
+		|> set(key: "aggregate", value: "p99.9")
+		|> set(key: "rollup_interval", value: string(v: task.every))
+		|> to(bucket: toBucket, timeColumn: "_stop")
+	all_data
+		|> map(fn: (r) =>
+			({r with _value: float(v: r._value)}))
+		|> quantile(
+			column: "_value",
+			q: 0.99,
+			method: "estimate_tdigest",
+			compression: 1000.0,
+		)
+		|> set(key: "aggregate", value: "p99")
+		|> set(key: "rollup_interval", value: string(v: task.every))
+		|> to(bucket: toBucket, timeColumn: "_stop")
+	all_data
+		|> map(fn: (r) =>
+			({r with _value: float(v: r._value)}))
+		|> quantile(
+			column: "_value",
+			q: 0.95,
+			method: "estimate_tdigest",
+			compression: 1000.0,
+		)
+		|> set(key: "aggregate", value: "p95")
+		|> set(key: "rollup_interval", value: string(v: task.every))
+		|> to(bucket: toBucket, timeColumn: "_stop")
+	all_data
+		|> map(fn: (r) =>
+			({r with _value: float(v: r._value)}))
+		|> quantile(
+			column: "_value",
+			q: 0.9,
+			method: "estimate_tdigest",
+			compression: 1000.0,
+		)
+		|> set(key: "aggregate", value: "p90")
+		|> set(key: "rollup_interval", value: string(v: task.every))
+		|> to(bucket: toBucket, timeColumn: "_stop")
+	all_data
+		|> aggregateWindow(every: task.every, fn: count)
+		|> map(fn: (r) =>
+			({r with _value: float(v: r._value)}))
+		|> set(key: "aggregate", value: "count")
+		|> set(key: "rollup_interval", value: string(v: task.every))
+		|> to(bucket: toBucket)
+	all_data
+		|> aggregateWindow(every: task.every, fn: last)
+		|> set(key: "aggregate", value: "last")
+		|> set(key: "rollup_interval", value: string(v: task.every))
+		|> to(bucket: toBucket)

--- a/infra/influxdb2/tasks/downsampling/downsampling_home_all.flux
+++ b/infra/influxdb2/tasks/downsampling/downsampling_home_all.flux
@@ -1,0 +1,93 @@
+// Query to dowsample data from "infra" bucket
+// downsample ALL data (no start time) from fromBucket
+// intended to be run on bucket with existing history, before 
+// we get a periodic downsampling task set up
+
+_every=1h
+fromBucket = "home"
+toBucket = "home_" + string(v: _every)
+	all_data = from(bucket: fromBucket)
+		|> range(start: -30d, stop: -25d)
+		|> filter(fn: (r) =>
+			(r._measurement == "Owens")
+				and exists r._value and (r._value >= 0 or r._value < 0))
+	all_data
+		|> aggregateWindow(every: _every, fn: mean)
+		|> set(key: "aggregate", value: "mean")
+		|> set(key: "rollup_interval", value: string(v: _every))
+		|> to(bucket: toBucket)
+	all_data
+		|> aggregateWindow(every: _every, fn: min)
+		|> set(key: "aggregate", value: "min")
+		|> set(key: "rollup_interval", value: string(v: _every))
+		|> to(bucket: toBucket)
+	all_data
+		|> aggregateWindow(every: _every, fn: max)
+		|> set(key: "aggregate", value: "max")
+		|> set(key: "rollup_interval", value: string(v: _every))
+		|> to(bucket: toBucket)
+	all_data
+		|> aggregateWindow(every: _every, fn: sum)
+		|> set(key: "aggregate", value: "sum")
+		|> set(key: "rollup_interval", value: string(v: _every))
+		|> to(bucket: toBucket)
+	all_data
+		|> map(fn: (r) =>
+			({r with _value: float(v: r._value)}))
+		|> quantile(
+			column: "_value",
+			q: 0.999,
+			method: "estimate_tdigest",
+			compression: 1000.0,
+		)
+		|> set(key: "aggregate", value: "p99.9")
+		|> set(key: "rollup_interval", value: string(v: _every))
+		|> to(bucket: toBucket, timeColumn: "_stop")
+	all_data
+		|> map(fn: (r) =>
+			({r with _value: float(v: r._value)}))
+		|> quantile(
+			column: "_value",
+			q: 0.99,
+			method: "estimate_tdigest",
+			compression: 1000.0,
+		)
+		|> set(key: "aggregate", value: "p99")
+		|> set(key: "rollup_interval", value: string(v: _every))
+		|> to(bucket: toBucket, timeColumn: "_stop")
+	all_data
+		|> map(fn: (r) =>
+			({r with _value: float(v: r._value)}))
+		|> quantile(
+			column: "_value",
+			q: 0.95,
+			method: "estimate_tdigest",
+			compression: 1000.0,
+		)
+		|> set(key: "aggregate", value: "p95")
+		|> set(key: "rollup_interval", value: string(v: _every))
+		|> to(bucket: toBucket, timeColumn: "_stop")
+	all_data
+		|> map(fn: (r) =>
+			({r with _value: float(v: r._value)}))
+		|> quantile(
+			column: "_value",
+			q: 0.9,
+			method: "estimate_tdigest",
+			compression: 1000.0,
+		)
+		|> set(key: "aggregate", value: "p90")
+		|> set(key: "rollup_interval", value: string(v: _every))
+		|> to(bucket: toBucket, timeColumn: "_stop")
+	all_data
+		|> aggregateWindow(every: _every, fn: count)
+		|> map(fn: (r) =>
+			({r with _value: float(v: r._value)}))
+		|> set(key: "aggregate", value: "count")
+		|> set(key: "rollup_interval", value: string(v: _every))
+		|> to(bucket: toBucket)
+	all_data
+		|> aggregateWindow(every: _every, fn: last)
+		|> set(key: "aggregate", value: "last")
+		|> set(key: "rollup_interval", value: string(v: _every))
+		|> to(bucket: toBucket)

--- a/infra/influxdb2/tasks/downsampling/downsampling_infra.flux
+++ b/infra/influxdb2/tasks/downsampling/downsampling_infra.flux
@@ -6,7 +6,8 @@ toBucket = "infra_" + string(v: task.every)
 	all_data = from(bucket: fromBucket)
 		|> range(start: -task.every)
 		|> filter(fn: (r) =>
-			(r._measurement =~ /^internal_.+$/))
+			(r._measurement =~ /^cpu|disk*|docker|kernel|mem|net|pf|proc*|swap|system|temp$/)
+				and exists r._value and (r._value >= 0 or r._value < 0))
 	all_data
 		|> aggregateWindow(every: task.every, fn: mean)
 		|> set(key: "aggregate", value: "mean")

--- a/infra/influxdb2/tasks/downsampling/downsampling_infra.flux
+++ b/infra/influxdb2/tasks/downsampling/downsampling_infra.flux
@@ -1,0 +1,89 @@
+// Query to dowsample data from "infra" bucket
+// https://github.com/influxdata/community-templates/blob/master/downsampling/all_inputs/downsampling_tasks.yml
+
+fromBucket = "infra"
+toBucket = "infra_" + string(v: task.every)
+	all_data = from(bucket: fromBucket)
+		|> range(start: -task.every)
+		|> filter(fn: (r) =>
+			(r._measurement =~ /^internal_.+$/))
+	all_data
+		|> aggregateWindow(every: task.every, fn: mean)
+		|> set(key: "aggregate", value: "mean")
+		|> set(key: "rollup_interval", value: string(v: task.every))
+		|> to(bucket: toBucket)
+	all_data
+		|> aggregateWindow(every: task.every, fn: min)
+		|> set(key: "aggregate", value: "min")
+		|> set(key: "rollup_interval", value: string(v: task.every))
+		|> to(bucket: toBucket)
+	all_data
+		|> aggregateWindow(every: task.every, fn: max)
+		|> set(key: "aggregate", value: "max")
+		|> set(key: "rollup_interval", value: string(v: task.every))
+		|> to(bucket: toBucket)
+	all_data
+		|> aggregateWindow(every: task.every, fn: sum)
+		|> set(key: "aggregate", value: "sum")
+		|> set(key: "rollup_interval", value: string(v: task.every))
+		|> to(bucket: toBucket)
+	all_data
+		|> map(fn: (r) =>
+			({r with _value: float(v: r._value)}))
+		|> quantile(
+			column: "_value",
+			q: 0.999,
+			method: "estimate_tdigest",
+			compression: 1000.0,
+		)
+		|> set(key: "aggregate", value: "p99.9")
+		|> set(key: "rollup_interval", value: string(v: task.every))
+		|> to(bucket: toBucket, timeColumn: "_stop")
+	all_data
+		|> map(fn: (r) =>
+			({r with _value: float(v: r._value)}))
+		|> quantile(
+			column: "_value",
+			q: 0.99,
+			method: "estimate_tdigest",
+			compression: 1000.0,
+		)
+		|> set(key: "aggregate", value: "p99")
+		|> set(key: "rollup_interval", value: string(v: task.every))
+		|> to(bucket: toBucket, timeColumn: "_stop")
+	all_data
+		|> map(fn: (r) =>
+			({r with _value: float(v: r._value)}))
+		|> quantile(
+			column: "_value",
+			q: 0.95,
+			method: "estimate_tdigest",
+			compression: 1000.0,
+		)
+		|> set(key: "aggregate", value: "p95")
+		|> set(key: "rollup_interval", value: string(v: task.every))
+		|> to(bucket: toBucket, timeColumn: "_stop")
+	all_data
+		|> map(fn: (r) =>
+			({r with _value: float(v: r._value)}))
+		|> quantile(
+			column: "_value",
+			q: 0.9,
+			method: "estimate_tdigest",
+			compression: 1000.0,
+		)
+		|> set(key: "aggregate", value: "p90")
+		|> set(key: "rollup_interval", value: string(v: task.every))
+		|> to(bucket: toBucket, timeColumn: "_stop")
+	all_data
+		|> aggregateWindow(every: task.every, fn: count)
+		|> map(fn: (r) =>
+			({r with _value: float(v: r._value)}))
+		|> set(key: "aggregate", value: "count")
+		|> set(key: "rollup_interval", value: string(v: task.every))
+		|> to(bucket: toBucket)
+	all_data
+		|> aggregateWindow(every: task.every, fn: last)
+		|> set(key: "aggregate", value: "last")
+		|> set(key: "rollup_interval", value: string(v: task.every))
+		|> to(bucket: toBucket)

--- a/infra/telegraf/telegraf.conf
+++ b/infra/telegraf/telegraf.conf
@@ -8982,6 +8982,8 @@
     "/usr/local/bin/bucket_du.sh data 750e569eda26237e",
     "/usr/local/bin/bucket_du.sh data 7ff00e7f80ba6df6",
     "/usr/local/bin/bucket_du.sh data e3c9ec2ea1a0a8fe",
+    "/usr/local/bin/bucket_du.sh data 39025694eb2666d9",
+    "/usr/local/bin/bucket_du.sh data cb212d10eaf46ef9",
     "/usr/local/bin/bucket_du.sh wal 10bd5e379f8d6d1e",
     "/usr/local/bin/bucket_du.sh wal 3d8f1c73ca769a8d",
     "/usr/local/bin/bucket_du.sh wal 46048908b4219eb4",
@@ -8989,6 +8991,8 @@
     "/usr/local/bin/bucket_du.sh wal 750e569eda26237e",
     "/usr/local/bin/bucket_du.sh wal 7ff00e7f80ba6df6",
     "/usr/local/bin/bucket_du.sh wal e3c9ec2ea1a0a8fe",
+    "/usr/local/bin/bucket_du.sh wal 39025694eb2666d9",
+    "/usr/local/bin/bucket_du.sh wal cb212d10eaf46ef9",
   ]
   interval="1h"
   ## Data format to consume.


### PR DESCRIPTION
Add tasks to downsample some of our buckets.
Based on https://github.com/influxdata/community-templates/blob/master/downsampling/all_inputs/downsampling_tasks.yml

Downsample the 'infra' bucket at 5m and 1h intervals

Downsample the 'home' bucket at 1h intervals.