### PR TITLE
OpenThread Border Router RCP

### DIFF
--- a/infra/openthread/nrf52840-rcp/Dockerfile
+++ b/infra/openthread/nrf52840-rcp/Dockerfile
@@ -1,4 +1,3 @@
-#FROM debian:11-slim
 FROM ubuntu:23.04
 
 RUN apt-get update \

--- a/infra/openthread/nrf52840-rcp/Dockerfile
+++ b/infra/openthread/nrf52840-rcp/Dockerfile
@@ -1,0 +1,24 @@
+#FROM debian:11-slim
+FROM ubuntu:23.04
+
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends \
+                ca-certificates \
+                git \
+                sudo \
+	&& apt-get clean \
+	&& apt-get autoremove -y
+
+# Get the source
+RUN git clone https://github.com/openthread/ot-nrf528xx.git
+WORKDIR ./ot-nrf528xx
+RUN git submodule update --init
+
+# Install the ARM toolchain
+RUN ./script/bootstrap
+
+# Build the flash image nRF52840 dongle support (PCA10059)
+RUN ./script/build nrf52840 USB_trans -DOT_BOOTLOADER=USB
+
+# Convert to hex
+RUN arm-none-eabi-objcopy -O ihex build/bin/ot-cli-ftd ot-cli-ftd.hex

--- a/infra/openthread/nrf52840-rcp/README.md
+++ b/infra/openthread/nrf52840-rcp/README.md
@@ -1,0 +1,15 @@
+#nRF52840 OpenThread Border Router RCP
+
+
+Builds firmware for nRF8240 dongle, for use as a Radio Co-processor for  
+an OpenThread Border Router device.
+
+## Usage
+	$ sudo docker build -t nrf52840-rcp .
+	$ sudo docker run --rm -v $PWD:/out nrf52840-rcp:latest cp ot-nrf528xx/ot-cli-ftd.hex /out/
+The firmware is hex format will be in $PWD/ot-cli-ftd.hex
+
+## References
+OTBR project: https://openthread.io/guides/border-router
+OTBR build with nRF52840: https://openthread.io/codelabs/openthread-hardware#0
+nRF52840 firmware: https://github.com/openthread/ot-nrf528xx/tree/main/src/nrf52840

--- a/infra/openthread/nrf52840-rcp/README.md
+++ b/infra/openthread/nrf52840-rcp/README.md
@@ -1,6 +1,5 @@
 #nRF52840 OpenThread Border Router RCP
 
-
 Builds firmware for nRF8240 dongle, for use as a Radio Co-processor for  
 an OpenThread Border Router device.
 


### PR DESCRIPTION
Docker image to pull source and build firmware for a nRF52840 dongle RCP for an OpenThread Border Router.